### PR TITLE
Issue 280

### DIFF
--- a/src/main/java/org/openbaton/nse/beans/adapters/openstack/NeutronQoSExecutor.java
+++ b/src/main/java/org/openbaton/nse/beans/adapters/openstack/NeutronQoSExecutor.java
@@ -411,7 +411,7 @@ public class NeutronQoSExecutor implements Runnable {
               //logger.debug("    Map qualities : " + netQualities);
 
               //logger.debug("Following QoS policies are to applied " + netQualities.toString());
-              for (NetworkIps ip : vnfci.getIps()) {
+              for (NetworkIps ip : vnfci.getFixedIps()) {
                 //logger.debug(
                 //    "Checking "
                 //        + vnfci.getHostname()

--- a/src/main/java/org/openbaton/nse/beans/adapters/openstack/NeutronQoSExecutor.java
+++ b/src/main/java/org/openbaton/nse/beans/adapters/openstack/NeutronQoSExecutor.java
@@ -37,6 +37,7 @@ import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
 */
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
 import org.openbaton.catalogue.mano.descriptor.InternalVirtualLink;
 import org.openbaton.catalogue.mano.descriptor.VNFDConnectionPoint;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
@@ -410,7 +411,7 @@ public class NeutronQoSExecutor implements Runnable {
               //logger.debug("    Map qualities : " + netQualities);
 
               //logger.debug("Following QoS policies are to applied " + netQualities.toString());
-              for (Ip ip : vnfci.getIps()) {
+              for (NetworkIps ip : vnfci.getIps()) {
                 //logger.debug(
                 //    "Checking "
                 //        + vnfci.getHostname()
@@ -423,7 +424,7 @@ public class NeutronQoSExecutor implements Runnable {
                   // Avoid duplicate entries
                   dup = false;
                   for (DetailedQoSReference t : res) {
-                    if (t.getIp().equals(ip.getIp())) {
+                    if (t.getIp().equals(ip.getSubnetIps().iterator().next().getIp())) {
                       dup = true;
                     }
                   }
@@ -433,7 +434,7 @@ public class NeutronQoSExecutor implements Runnable {
                     if (netQualities.get(net) != null) {
                       ref.setQuality(netQualities.get(net));
                       ref.setVim_id(vnfci.getVim_id());
-                      ref.setIp(ip.getIp());
+                      ref.setIp(ip.getSubnetIps().iterator().next().getIp());
                       ref.setVnfr_name(vnfr.getName());
                       //logger.debug("    Adding " + ref.toString());
                       res.add(ref);


### PR DESCRIPTION
Currently if there is more than one interface (openstack port) on a single network only the first interfaces's IP address is available to the scripts as $network_name. If there is more than one subnet associated with a particular network (i.e. IPv4 and IPv6) openstack assigns IP addresses from both but the value of $network_name in the scripts is randomly assigned between the two.

Update the VNFCInstance to have not only a single ip address per network but now have all ip addresses including their subnets and interface id's if specified in the vnfd.json file.


NOTE::::::::The base code from which this was pulled did not yet have the division into BaseVimInstance, OpenstackVimInstance and AmazonVimInstance so it will NOT compile against the referenced NFVO version.

This references issue openbaton/NFVO#280 and should be pulled with openbaton/NFVO#281