### PR TITLE
Add support for HTTP POST in neutron_http_connection

### DIFF
--- a/src/main/java/org/openbaton/nse/adapters/openstack/NeutronQoSHandler.java
+++ b/src/main/java/org/openbaton/nse/adapters/openstack/NeutronQoSHandler.java
@@ -62,6 +62,10 @@ public class NeutronQoSHandler {
         connection.setRequestMethod("PUT");
         connection.setRequestProperty("Accept", "application/json");
         connection.setRequestProperty("Content-Type", "application/json");
+      } else if (method.equals("POST")) {
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setRequestProperty("Content-Type", "application/json");
       } else if (method.equals("DELETE")) {
         connection.setRequestMethod("DELETE");
         connection.setRequestProperty("Accept", "application/json");


### PR DESCRIPTION
Add support for HTTP POST in neutron_http_connection, which is required for proper operation of several methods (e.g., NeutronQoSExecutor:createQoSPolicy)